### PR TITLE
Fixed bug reported by Provincia Wifi

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :http_authenticatable, :token_authenticatable, :recoverable,
   # :confirmable, :lockable, :timeoutable, :registerable and :activatable
-  devise :database_authenticatable, :rememberable, :trackable, :token_authenticatable
+  devise :database_authenticatable, :rememberable, :trackable
 
   # Setup accessible (or protected) attributes for your model
   attr_accessible :username, :email, :password, :password_confirmation


### PR DESCRIPTION
Removed :token_authenticatable from user model.
Reason: unnecessary, it caused a bug reported by ProvinciaWifi
